### PR TITLE
feat: 스크롤 시 Header 숨김 기능 추가

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import useOnScrollHide from "@/lib/hooks/useOnScrollHide";
 import { useState } from "react";
 import { RiMenuLine } from "react-icons/ri";
 import Icon from "./atoms/Icon";
@@ -7,10 +8,17 @@ import TabMenu from "./TabMenu";
 
 export default function Header() {
   const [toggle, setToggle] = useState(false);
+  const isHide = useOnScrollHide();
 
   return (
-    <header className="flex fixed top-0 left-0 w-full justify-between items-center px-10 pt-5 h-20 z-10">
-      <h1 className="text-5xl text-teal-700 font-semibold">장미당</h1>
+    <header
+      className={`flex fixed top-0 left-0 w-full justify-between items-center px-10 pt-5 h-20 z-10  duration-500 ${
+        isHide ? "opacity-0" : "opacity-100"
+      } hover:opacity-100 hover:duration-200`}
+    >
+      <h1 className={`text-5xl text-teal-700 font-semibold`}>
+        <a href="/">장미당</a>
+      </h1>
       <Icon size="lg" icon={<RiMenuLine size={24} />} onClick={() => setToggle(true)} />
       <TabMenu toggle={toggle} setToggle={setToggle} />
     </header>

--- a/components/atoms/Icon.tsx
+++ b/components/atoms/Icon.tsx
@@ -4,6 +4,7 @@ interface IProps extends Omit<ComponentProps<"input">, "size"> {
   icon: ReactElement;
   size?: "sm" | "md" | "lg";
   color?: "white" | "black";
+  className?: string;
 }
 
 const colors = {
@@ -17,12 +18,12 @@ const sizes = {
   lg: "w-16 h-16",
 };
 
-export default function Icon({ icon, size = "md", color = "white", ...rest }: IProps) {
+export default function Icon({ icon, size = "md", color = "white", className, ...rest }: IProps) {
   const iconOption = `${sizes[size]} ${colors[color]}`;
 
   return (
     <div
-      className={`rounded-full ${iconOption} flex items-center justify-center cursor-pointer`}
+      className={`rounded-full ${iconOption} flex items-center justify-center cursor-pointer ${className}`}
       {...rest}
     >
       {icon}

--- a/components/moecules/ProductCard.tsx
+++ b/components/moecules/ProductCard.tsx
@@ -8,7 +8,7 @@ export default function ProductCard({ cardData }: IProps) {
   const { id, img, title, description } = cardData;
   return (
     <div className="w-full rounded-2xl overflow-hidden pb-5 bg-slate-200">
-      <a href={`${process.env.BASE_URL}product/${id}`}>
+      <a href={`/product/${id}`}>
         <img src={img} alt="" className="w-full h-3/5 object-cover" />
       </a>
       <strong className="block mt-5 px-5 font-bold leading-5 text-ellipsis whitespace-nowrap overflow-hidden">

--- a/lib/hooks/useOnScrollHide.ts
+++ b/lib/hooks/useOnScrollHide.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from "react";
+
+const useOnScrollHide = (): boolean => {
+  const [isHide, setIsHide] = useState(false);
+  const prevScrollTop = useRef(0);
+
+  const handleScroll = () => {
+    let nextScrollTop = window.scrollY || 0;
+    if (nextScrollTop > prevScrollTop.current) {
+      setIsHide(true);
+    } else if (nextScrollTop < prevScrollTop.current) {
+      setIsHide(false);
+    }
+    prevScrollTop.current = nextScrollTop;
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  });
+
+  return isHide;
+};
+
+export default useOnScrollHide;


### PR DESCRIPTION
## 작업내용
- `useOnScrollHide` 커스텀 훅을 생성하여 아래로 스크롤 시 `true` 위로 스크롤 시 `false` 되는 `isHide`  변수 return
- `useOnScrollHide` 훅을 사용해서 아래로 스크롤 시 Header 숨기도록 변경 (호버 또는 위로 스크롤 시 visible)

## 스크린샷
![cap](https://github.com/tnghgks/jangmidang/assets/17325845/6cb471e0-8576-45c3-a746-bbfa8bd98a84)
